### PR TITLE
Updated requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 .vscode/
 pdfs/
 gpt_indexes/
+
+# Julian is epic and cool (ignore these)
+foundations.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -163,5 +163,5 @@ cython_debug/
 pdfs/
 gpt_indexes/
 
-# Julian is epic and cool (ignore these)
-foundations.pdf
+# Ignore all .pdfs the user may of added (for security)
+*.pdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,11 @@ charset-normalizer==3.1.0
 click==8.1.3
 colorama==0.4.6
 dataclasses-json==0.5.7
+filelock==3.12.0
 frozenlist==1.3.3
 fsspec==2023.5.0
 greenlet==2.0.2
+huggingface-hub==0.14.1
 idna==3.4
 inquirer==3.1.3
 jinxed==1.2.0
@@ -48,7 +50,10 @@ SQLAlchemy==2.0.15
 tenacity==8.2.2
 termcolor==2.3.0
 tiktoken==0.4.0
+tokenizers==0.13.3
+tomli==2.0.1
 tqdm==4.65.0
+transformers==4.29.2
 typing-inspect==0.8.0
 typing_extensions==4.5.0
 tzdata==2023.3


### PR DESCRIPTION
> Using `python3.8`

Running `pydocuchat.py` in my virtual environment using `requirements.txt` it asked to install `transformers`. I also added a new update to git ignore so that users couldn't accidentally push private PDFs they are using.